### PR TITLE
Fail bad creds build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test: ## run pytest in parallel with coverage reporting. Fail under 100% code coverage
-	pytest -W error \
+	python3 -m pytest -W error \
 		--cov-report term \
 		--cov-report html:htmlcov \
 		--cov=watson_embed_model_packager \
@@ -22,7 +22,7 @@ clean: ## clean up build artifacts and test reports
 	rm -fr build dist htmlcov reports *.egg-info .coverage
 
 fmt:
-	black . && isort .
+	python3 -m black . && python3 -m isort .
 
 fmt-check:
 	black --check . && isort --check .

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test: ## run pytest in parallel with coverage reporting. Fail under 100% code coverage
-	python3 -m pytest -W error \
+	pytest -W error \
 		--cov-report term \
 		--cov-report html:htmlcov \
 		--cov=watson_embed_model_packager \
@@ -22,7 +22,7 @@ clean: ## clean up build artifacts and test reports
 	rm -fr build dist htmlcov reports *.egg-info .coverage
 
 fmt:
-	python3 -m black . && python3 -m isort .
+	black . && isort .
 
 fmt-check:
 	black --check . && isort --check .

--- a/tests/data/artifactory_model_config.csv
+++ b/tests/data/artifactory_model_config.csv
@@ -1,0 +1,2 @@
+model_name,target_image_name,model_source,image_labels
+nlp_keywords_text-rank_en,us.icr.io/cp/watson-ai/nlp-keywords-text-rank-en:latest,https://na.artifactory.swg-devops.com/artifactory/wcp-nlu-team-one-nlp-models-generic-local/workflows/keywords/keywords_text-rank-workflow_v1-2-0_lang_en_stock_2020-06-04-190000.zip,com.ibm.watson.embed.library_version=1.2.0;com.ibm.watson.embed.created=2020-06-04 19:00:00.000000;com.ibm.watson.embed.module_class=watson_nlp.workflows.keywords.text_rank.Text_Rank

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -18,6 +18,7 @@ TEST_DATA_DIR = os.path.realpath(
     )
 )
 TEST_CONFIG = os.path.join(TEST_DATA_DIR, "model_config.csv")
+TEST_CONFIG_ARTIFACTORY_ONLY = os.path.join(TEST_DATA_DIR, "artifactory_model_config.csv")
 TEST_MODEL = os.path.join(TEST_DATA_DIR, "sample_models", "doc_conversion")
 TEST_MODELS_DIR = os.path.join(TEST_DATA_DIR, "sample_models")
 TEST_LABELS = "com.ibm.watson.embed.library_version=1.2.3;com.ibm.watson.embed.watson_library=watson_nlp;com.ibm.watson.embed.created=2020-06-04 19:00:00.000000;com.ibm.watson.embed.module_class=watson_nlp.workflows.keywords.text_rank.Text_Rank;com.ibm.watson.embed.module_guid=asdf1234"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -18,7 +18,9 @@ TEST_DATA_DIR = os.path.realpath(
     )
 )
 TEST_CONFIG = os.path.join(TEST_DATA_DIR, "model_config.csv")
-TEST_CONFIG_ARTIFACTORY_ONLY = os.path.join(TEST_DATA_DIR, "artifactory_model_config.csv")
+TEST_CONFIG_ARTIFACTORY_ONLY = os.path.join(
+    TEST_DATA_DIR, "artifactory_model_config.csv"
+)
 TEST_MODEL = os.path.join(TEST_DATA_DIR, "sample_models", "doc_conversion")
 TEST_MODELS_DIR = os.path.join(TEST_DATA_DIR, "sample_models")
 TEST_LABELS = "com.ibm.watson.embed.library_version=1.2.3;com.ibm.watson.embed.watson_library=watson_nlp;com.ibm.watson.embed.created=2020-06-04 19:00:00.000000;com.ibm.watson.embed.module_class=watson_nlp.workflows.keywords.text_rank.Text_Rank;com.ibm.watson.embed.module_guid=asdf1234"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -54,7 +54,7 @@ def test_main_real_artifactory_build_with_bad_creds():
         "foobar@us.ibm.com",
         "--artifactory-api-key",
         "asdf1234",
-        "--strict"
+        "--strict",
     ):
         with pytest.raises(RuntimeError):
             main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -54,6 +54,7 @@ def test_main_real_artifactory_build_with_bad_creds():
         "foobar@us.ibm.com",
         "--artifactory-api-key",
         "asdf1234",
+        "--strict"
     ):
         with pytest.raises(RuntimeError):
             main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,6 +17,7 @@ from watson_embed_model_packager.__main__ import main
 # Local
 from tests.helpers import (
     TEST_CONFIG,
+    TEST_CONFIG_ARTIFACTORY_ONLY,
     TEST_MODELS_DIR,
     cli_args,
     subproc_mock_fixture_base,
@@ -42,6 +43,19 @@ def test_main_build(subproc_mock):
         "asdf1234",
     ):
         main()
+
+def test_main_real_artifactory_build_with_bad_creds():
+    with cli_args(
+        "build",
+        "--config",
+        TEST_CONFIG_ARTIFACTORY_ONLY,
+        "--artifactory-username",
+        "foobar@us.ibm.com",
+        "--artifactory-api-key",
+        "asdf1234",
+    ):
+        with pytest.raises(RuntimeError):
+            main()
 
 
 def test_main_real_artifactory_build():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -44,6 +44,7 @@ def test_main_build(subproc_mock):
     ):
         main()
 
+
 def test_main_real_artifactory_build_with_bad_creds():
     with cli_args(
         "build",

--- a/watson_embed_model_packager/resources/artifactory.dockerfile
+++ b/watson_embed_model_packager/resources/artifactory.dockerfile
@@ -37,6 +37,7 @@ ARG ARTIFACTORY_API_KEY
 RUN true && \
     cd / && \
     curl -o model.zip \
+        --fail \
         -u ${ARTIFACTORY_USERNAME}:${ARTIFACTORY_API_KEY} \
         ${MODEL_URL} && \
     chmod 444 model.zip && \


### PR DESCRIPTION
We need to fail the Docker build when `curl`ing for artifactory with bad creds