### PR TITLE
:sparkles: Support s3 storage config files

### DIFF
--- a/watson_embed_model_packager/resources/artifactory.dockerfile
+++ b/watson_embed_model_packager/resources/artifactory.dockerfile
@@ -18,13 +18,14 @@ ENV BIN_OUT_PATH=/bin_out
 ENV LIB_OUT_PATH=/lib_out
 RUN true && \
     microdnf update -y && \
-    microdnf install -y which unzip findutils openssl util-linux && \
+    microdnf install -y which unzip findutils openssl util-linux jq && \
     /copy_bin_with_libs.sh openssl && \
     /copy_bin_with_libs.sh curl && \
     /copy_bin_with_libs.sh sed && \
     /copy_bin_with_libs.sh unzip && \
     /copy_bin_with_libs.sh find && \
     /copy_bin_with_libs.sh rev && \
+    /copy_bin_with_libs.sh jq && \
     true
 
 # Build-time arguments that won't go into the release

--- a/watson_embed_model_packager/resources/local.dockerfile
+++ b/watson_embed_model_packager/resources/local.dockerfile
@@ -18,13 +18,14 @@ ENV BIN_OUT_PATH=/bin_out
 ENV LIB_OUT_PATH=/lib_out
 RUN true && \
     microdnf update -y && \
-    microdnf install -y which zip findutils openssl util-linux && \
+    microdnf install -y which zip findutils openssl util-linux jq && \
     /copy_bin_with_libs.sh openssl && \
     /copy_bin_with_libs.sh curl && \
     /copy_bin_with_libs.sh sed && \
     /copy_bin_with_libs.sh unzip && \
     /copy_bin_with_libs.sh find && \
     /copy_bin_with_libs.sh rev && \
+    /copy_bin_with_libs.sh jq && \
     chmod ugo+rx /bin_out/* && \
     chmod ugo+r /lib_out/* && \
     true

--- a/watson_embed_model_packager/resources/unpack_model.sh
+++ b/watson_embed_model_packager/resources/unpack_model.sh
@@ -66,10 +66,21 @@ input_path=$(echo $model_dir | sed "s,^$model_root_dir,," | sed "s,^/,,")
 # If uploading, do the upload
 if [ "$upload" == "true" ]
 then
-    url=$S3_URL
-    key=$S3_ACCESS_KEY_ID
-    secret=$S3_SECRET_ACCESS_KEY
-    bucket=$S3_BUCKET_NAME
+    storage_config_file=${S3_CONFIG_FILE:-""}
+    if [ -f $storage_config_file ]
+    then
+        # Using -r (raw) to not include the quotes around the values
+        url=$(jq -r .endpoint_url "$storage_config_file")
+        key=$(jq -r .access_key_id "$storage_config_file")
+        secret=$(jq -r .secret_access_key "$storage_config_file")
+        bucket=$(jq -r .default_bucket "$storage_config_file")
+    else
+        url=$S3_URL
+        key=$S3_ACCESS_KEY_ID
+        secret=$S3_SECRET_ACCESS_KEY
+        bucket=$S3_BUCKET_NAME
+    fi
+
     base_upload_path=$UPLOAD_PATH
 
     # If the upload path is a single file, just upload it


### PR DESCRIPTION
This adds support for kserve-style storage config files.
This will allow a user to mount in a file from a secret that looks like:
```
{
    "type": "s3",
    "access_key_id": "xxxxxxxx",
    "secret_access_key": "xxxxxxxxxxxxxxxxxxx",
    "endpoint_url": "https://s3.us-south.cloud-object-storage.appdomain.cloud",
    "region": "us-south",
    "default_bucket": "my-bucket"
}
```
and the secret deets will be parsed out of there, instead of requiring them to be set in the environment.

This does add `jq` to the containers, which adds 1.9MB of overhead. Sorry @gabe-l-hart 