### PR TITLE
🚸 Change default tag to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ python3 -m watson_embed_model_packager setup \
     --library-version watson_nlp:3.2.0 \
     --artifactory-repo https://my.artifactory.com/artifactory/my-watson-nlp-models/ \
     --target-registry my-docker-registry.com \
+    --image-tag 1.2.3 \
     --output-csv model-manifest.csv
 ```
 
@@ -63,6 +64,7 @@ Run the manifest setup with the `--local-model-dir` flag to create a manifest wi
 python3 -m watson_embed_model_packager setup \
     --library-version watson_nlp:3.2.0 \
     --local-model-dir /path/to/models \
+    --image-tag 1.2.3 \
     --output-csv model-manifest.csv
 ```
 

--- a/tests/test_setup_build_config.py
+++ b/tests/test_setup_build_config.py
@@ -614,21 +614,10 @@ def test_image_tag_is_included_in_csv_if_passed_in():
         assert "0.0.5" in model_entries[0][constants.TARGET_IMAGE_NAME]
 
 
-def test_image_tag_is_included_in_csv_coming_from_library_version():
+def test_images_are_tagged_latest_if_image_tag_flag_unset():
     """Make sure that model image tag is included in csv file, when there's no --image-tag flag set"""
-    model_name = make_model_name(
-        module_type="ensemble", model_label="classification-workflow"
-    )
     with cli_test_harness(
-        {
-            f"/blocks/sample/{model_name}": make_model_content(
-                {
-                    "block_class": "lego.blocks.sample.testing.Tester",
-                    "block_id": MODULE_GUID,
-                    "lego_version": "1.2.3",
-                }
-            )
-        },
+        REPO_DATA,
         "-m",
         MODULE_GUID,
     ) as output_csv:
@@ -636,7 +625,7 @@ def test_image_tag_is_included_in_csv_coming_from_library_version():
         model_entries = parse_csv_file(output_csv)
         assert len(model_entries) == 1
         print(model_entries[0])
-        assert "1.2.3" in model_entries[0][constants.TARGET_IMAGE_NAME]
+        assert "latest" in model_entries[0][constants.TARGET_IMAGE_NAME]
 
 
 def test_image_tag_is_included_in_csv_coming_from_flag_not_library_version():

--- a/watson_embed_model_packager/setup_build_config.py
+++ b/watson_embed_model_packager/setup_build_config.py
@@ -514,7 +514,7 @@ def get_target_image_name(
     """Get the image name that should be used to tag the built image"""
     lib_prefix = model_info.parent_library.replace("_", "-")
     image_name = f"{lib_prefix}_{model_info.name}"
-    image_version = image_tag if image_tag else str(model_info.parent_library_version)
+    image_version = image_tag if image_tag else "latest"
     full_name = f"{image_name}:{image_version}"
     if target_registry:
         full_name = "{}/{}".format(target_registry.rstrip("/"), full_name)


### PR DESCRIPTION
This adds info in the readme about the `--image-tag` option and changes the default tag to be `latest` instead of the library version that a model was trained with