### PR TITLE
Support zip files for the `local-model-dir` build case

### DIFF
--- a/tests/test_setup_build_config.py
+++ b/tests/test_setup_build_config.py
@@ -286,10 +286,14 @@ def cli_test_harness(
                     with open(os.path.join(current_model_dir, file_name[1:]), "w") as f:
                         f.write(file_data)
                 if zipped_model:
+                    print(
+                        "making archive file name .zip: ",
+                        os.path.join(model_dir, model_name),
+                    )
                     shutil.make_archive(
                         base_name=os.path.join(model_dir, model_name),
                         format="zip",
-                        root_dir=current_model_dir,
+                        root_dir=model_dir,
                     )
                     shutil.rmtree(current_model_dir)
             if include_output_csv:
@@ -464,6 +468,28 @@ def test_local_model_as_zip():
     """
     with cli_test_harness(
         LOCAL_DATA,
+        "-it",
+        "1.3.2",
+        local_model=True,
+        zipped_model=True,
+    ) as output_csv:
+        command.main()
+        model_entries = parse_csv_file(output_csv)
+        assert len(model_entries) == 1
+
+
+def test_local_model_with_version_in_config():
+    """Make sure that local model has version in its config is counted"""
+    with cli_test_harness(
+        {
+            f"my_local_model": make_model_content(
+                {
+                    "block_class": "lego.blocks.sample.testing.Tester",
+                    "block_id": MODULE_GUID,
+                    "version": "1.2.4",
+                }
+            )
+        },
         "-it",
         "1.3.2",
         local_model=True,

--- a/tests/test_setup_build_config.py
+++ b/tests/test_setup_build_config.py
@@ -478,6 +478,40 @@ def test_local_model_as_zip():
         assert len(model_entries) == 1
 
 
+def test_local_model_with_multiple_zip_files():
+    """Test that the case of running the command with a multiple models as a zip files locally
+    yields the desired result
+    """
+    with cli_test_harness(
+        {
+            f"my_local_model": make_model_content(
+                {
+                    "block_class": "lego.blocks.sample.testing.Tester",
+                    "block_id": MODULE_GUID,
+                    "version": "1.2.4",
+                }
+            ),
+            f"my_local_model_2": make_model_content(
+                {
+                    "block_class": "lego.blocks.sample.testing.Tester",
+                    "block_id": MODULE_GUID + "2",
+                    "version": "9.9.9",
+                }
+            ),
+        },
+        "-it",
+        "1.3.2",
+        local_model=True,
+        zipped_model=True,
+    ) as output_csv:
+        command.main()
+        model_entries = parse_csv_file(output_csv)
+        assert len(model_entries) == 2
+        # no idea which model is at index 0, so we're just testing the values are different
+        assert model_entries[0]["image_labels"] != model_entries[1]["image_labels"]
+        assert model_entries[0]["model_source"] != model_entries[1]["model_source"]
+
+
 def test_local_model_with_version_in_config():
     """Make sure that local model has version in its config is counted"""
     with cli_test_harness(

--- a/watson_embed_model_packager/build_model_images.py
+++ b/watson_embed_model_packager/build_model_images.py
@@ -186,40 +186,31 @@ def build_model_image(
                         if not os.path.isdir(fname)
                     }
 
-                else:
-                    # TODO: this is probably a zip and zips probably won't work :D
-                    log.debug2("Linking single model file...")
-                    model_files = {
-                        os.path.realpath(model_config.model_source): os.path.basename(
-                            model_config.model_source
-                        ),
-                    }
+                    log.debug4(f"Model files: {model_files}")
 
-                log.debug4(f"Model files: {model_files}")
+                    for file_source_path, file_target_path in model_files.items():
+                        target = os.path.join(working_dir, file_target_path)
+                        parent_dir = os.path.dirname(file_target_path)
+                        if parent_dir:
+                            log.debug2(
+                                "Making joined parent dir %s",
+                                os.path.join(working_dir, parent_dir),
+                            )
+                            os.makedirs(
+                                os.path.join(working_dir, parent_dir),
+                                exist_ok=True,
+                            )
+                        log.debug2("Linking %s -> %s", file_source_path, target)
+                        link_or_copy(file_source_path, target)
 
-                for file_source_path, file_target_path in model_files.items():
-                    target = os.path.join(working_dir, file_target_path)
-                    parent_dir = os.path.dirname(file_target_path)
-                    if parent_dir:
-                        log.debug2(
-                            "Making joined parent dir %s",
-                            os.path.join(working_dir, parent_dir),
-                        )
-                        os.makedirs(
-                            os.path.join(working_dir, parent_dir),
-                            exist_ok=True,
-                        )
-                    log.debug2("Linking %s -> %s", file_source_path, target)
-                    link_or_copy(file_source_path, target)
-
-                # Do the docker build
-                do_docker_build(
-                    dockerfile=dockerfile,
-                    working_dir=working_dir,
-                    image_tag=model_config.target_image_name,
-                    build_args=build_args,
-                    build_labels=build_labels,
-                )
+                    # Do the docker build
+                    do_docker_build(
+                        dockerfile=dockerfile,
+                        working_dir=working_dir,
+                        image_tag=model_config.target_image_name,
+                        build_args=build_args,
+                        build_labels=build_labels,
+                    )
 
         # Otherwise, use the artifactory build and validate the credentials
         else:

--- a/watson_embed_model_packager/setup_build_config.py
+++ b/watson_embed_model_packager/setup_build_config.py
@@ -507,16 +507,14 @@ def get_models_from_local_dir(model_dir_path: str) -> List[ModelInfo]:
             )
 
     for child_dir in os.listdir(model_dir_path):
-        if not child_dir.startswith("__MACOSX"):
-            full_model_dir = os.path.join(model_dir_path, child_dir)
-            if os.path.isdir(full_model_dir) and "config.yml" in os.listdir(
-                full_model_dir
-            ):
-                log.debug("Looking in child_dir %s", full_model_dir)
-                model = get_model_info_from_local_config_yml(
-                    child_dir, os.path.join(full_model_dir, "config.yml")
-                )
-                local_models.append(model)
+        # if not child_dir.startswith("__MACOSX"):
+        full_model_dir = os.path.join(model_dir_path, child_dir)
+        if os.path.isdir(full_model_dir) and "config.yml" in os.listdir(full_model_dir):
+            log.debug("Looking in child_dir %s", full_model_dir)
+            model = get_model_info_from_local_config_yml(
+                child_dir, os.path.join(full_model_dir, "config.yml")
+            )
+            local_models.append(model)
 
     log.debug3("Models for local dir [%s]: %s", model_dir_path, local_models)
 


### PR DESCRIPTION
Signed-off-by: Angel Luu <angel.luu@us.ibm.com>


Test locally:
- Set up `my_local_model` directory with these 2 zip files, one for `syntax` and one for `categories`
<img width="457" alt="Screen Shot 2022-10-19 at 4 35 49 PM" src="https://user-images.githubusercontent.com/1454122/196817479-323493a4-e48e-44da-b3ab-60da8783dc84.png">

- To run `setup` script, run: 
```
python3 -m watson_embed_model_packager setup \         
    --library-version watson_nlp:3.2.0 \
    --local-model-dir my_local_model \
    --image-tag 9.9.9 \
    --output-csv model-manifest.csv
```

Note that this `setup` now extracts the zip files into directories, and those are the `model_source`s for the manifest output file.
<img width="360" alt="Screen Shot 2022-10-19 at 4 46 39 PM" src="https://user-images.githubusercontent.com/1454122/196818833-6c037a34-3c69-4e4a-9660-c1d74d38cad1.png">

Check out the `model-manifest.csv` file to see correctly 2 entries. Like this:

```
model_name,target_image_name,model_source,image_labels
categories_esa-workflow_lang_en_stock,watson-nlp_categories_esa-workflow_lang_en_stock:9.9.9,my_local_model/categories_esa-workflow_lang_en_stock,com.ibm.watson.embed.watson_library=watson_nlp;com.ibm.watson.embed.library_version=3.2.0;com.ibm.watson.embed.module_guid=2cc95ffd-00fe-4d7d-9554-61d8777f3354;com.ibm.watson.embed.module_class=watson_nlp.workflows.categories.esa_hierarchical.ESAHierarchical;com.ibm.watson.embed.created=2022-10-13 10:35:03.982323
syntax_izumo_lang_en_stock,watson-nlp_syntax_izumo_lang_en_stock:9.9.9,my_local_model/syntax_izumo_lang_en_stock,com.ibm.watson.embed.watson_library=watson_nlp;com.ibm.watson.embed.library_version=0.0.1;com.ibm.watson.embed.module_guid=e9a949e6-b4a6-11e9-9340-88e9fe7a20be;com.ibm.watson.embed.module_class=watson_nlp.blocks.syntax.izumo.IzumoTextProcessing;com.ibm.watson.embed.created=2022-10-19 16:25:16.772842
```

- Then to `build`, run:
```
python3 -m watson_embed_model_packager build --config model-manifest.csv
```
and see 2 images for syntax and categories correctly built when `docker images`. They should be tagged 9.9.9 as specified above.

I also went ahead and ran:
```
docker run --rm -v "$(pwd)/models:/app/models" -e ACCEPT_LICENSE=true watson-nlp_categories_esa-workflow_lang_en_stock:9.9.9
```
Then `cd models/categories_esa-workflow_lang_en_stock` and `ls` to make sure all content was there from the original categories model