### PR TITLE
:bug: ignore tracking id

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,7 @@
 pylint>=2.12.2,<3.0
 coverage>=6.2,<7.0
-pytest>=7.0,<7.2.1
-pytest-cov>=2.10.1,<3.0
+pytest>=7.0,<8.0
+pytest-cov>=4.0,<5.0
 pytest-html>=3.1.1,<4.0
 pytest-xdist==2.5.0
 wheel>=0.37.1,<1.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,6 @@
 pylint>=2.12.2,<3.0
 coverage>=6.2,<7.0
-pytest>=7.0
+pytest>=7.0,<7.2.1
 pytest-cov>=2.10.1,<3.0
 pytest-html>=3.1.1,<4.0
 pytest-xdist==2.5.0

--- a/watson_embed_model_packager/setup_build_config.py
+++ b/watson_embed_model_packager/setup_build_config.py
@@ -387,7 +387,7 @@ def update_model_info_from_config(
     config, model_name: str, model_path="", model_url="", local_model=False
 ) -> Optional[ModelInfo]:
     # Get the guid for this model's module
-    id_fields = [key for key in config.keys() if key.endswith("_id")]
+    id_fields = [key for key in config.keys() if key.endswith("_id") and key != "tracking_id"]
     if len(id_fields) != 1:
         log.warning("No single module guid found for model with config [%s]", config)
         return None

--- a/watson_embed_model_packager/setup_build_config.py
+++ b/watson_embed_model_packager/setup_build_config.py
@@ -387,7 +387,9 @@ def update_model_info_from_config(
     config, model_name: str, model_path="", model_url="", local_model=False
 ) -> Optional[ModelInfo]:
     # Get the guid for this model's module
-    id_fields = [key for key in config.keys() if key.endswith("_id") and key != "tracking_id"]
+    id_fields = [
+        key for key in config.keys() if key.endswith("_id") and key != "tracking_id"
+    ]
     if len(id_fields) != 1:
         log.warning("No single module guid found for model with config [%s]", config)
         return None


### PR DESCRIPTION
When models are built from .zip files and not pulled from artifactory, things now get a little confused by the recent addition of `tracking_id` in the model metadata