### PR TITLE
Fix workflow as a zip

### DIFF
--- a/tests/test_setup_build_config.py
+++ b/tests/test_setup_build_config.py
@@ -293,7 +293,7 @@ def cli_test_harness(
                     shutil.make_archive(
                         base_name=os.path.join(model_dir, model_name),
                         format="zip",
-                        root_dir=model_dir,
+                        root_dir=current_model_dir,
                     )
                     shutil.rmtree(current_model_dir)
             if include_output_csv:
@@ -492,6 +492,40 @@ def test_local_model_with_multiple_zip_files():
                 }
             ),
             f"my_local_model_2": make_model_content(
+                {
+                    "block_class": "lego.blocks.sample.testing.Tester",
+                    "block_id": MODULE_GUID + "2",
+                    "version": "9.9.9",
+                }
+            ),
+        },
+        "-it",
+        "1.3.2",
+        local_model=True,
+        zipped_model=True,
+    ) as output_csv:
+        command.main()
+        model_entries = parse_csv_file(output_csv)
+        assert len(model_entries) == 2
+        # no idea which model is at index 0, so we're just testing the values are different
+        assert model_entries[0]["image_labels"] != model_entries[1]["image_labels"]
+        assert model_entries[0]["model_source"] != model_entries[1]["model_source"]
+
+
+def test_local_model_with_mixed_zip_files():
+    """Test that the case of running the command with a multiple models mix of workflows and blocks as a zip files locally
+    yields the desired result
+    """
+    with cli_test_harness(
+        {
+            f"my_local_workflow": make_model_content(
+                {
+                    "workflow_class": "lego.workflows.sample.testing.Tester",
+                    "workflow_id": MODULE_GUID,
+                    "version": "1.2.4",
+                }
+            ),
+            f"my_local_block": make_model_content(
                 {
                     "block_class": "lego.blocks.sample.testing.Tester",
                     "block_id": MODULE_GUID + "2",

--- a/watson_embed_model_packager/setup_build_config.py
+++ b/watson_embed_model_packager/setup_build_config.py
@@ -496,13 +496,12 @@ def get_models_from_local_dir(model_dir_path: str) -> List[ModelInfo]:
     for zip_file in os.listdir(model_dir_path):
         path_to_zip_file = os.path.join(model_dir_path, zip_file)
         if os.path.isfile(path_to_zip_file) and path_to_zip_file.endswith(".zip"):
+            new_dir_loc = path_to_zip_file.replace(".zip", "")
             log.debug(
-                "Extracting zip file %s into location %s",
-                path_to_zip_file,
-                model_dir_path,
+                "Extracting zip file %s into location %s", path_to_zip_file, new_dir_loc
             )
             with zipfile.ZipFile(path_to_zip_file, "r") as zip_ref:
-                zip_ref.extractall(model_dir_path)
+                zip_ref.extractall(new_dir_loc)
                 zip_ref.close()
             log.debug(
                 "%s now has child dir %s", model_dir_path, os.listdir(model_dir_path)
@@ -511,8 +510,9 @@ def get_models_from_local_dir(model_dir_path: str) -> List[ModelInfo]:
     for child_dir in os.listdir(model_dir_path):
         # if not child_dir.startswith("__MACOSX"):
         full_model_dir = os.path.join(model_dir_path, child_dir)
+        log.debug("Inspecting path: %s", full_model_dir)
         if os.path.isdir(full_model_dir) and "config.yml" in os.listdir(full_model_dir):
-            log.debug("Looking in child_dir %s", full_model_dir)
+            log.debug("Found a model here: %s", full_model_dir)
             model = get_model_info_from_local_config_yml(
                 child_dir, os.path.join(full_model_dir, "config.yml")
             )


### PR DESCRIPTION
When packaging multiple zip files, the zip files could be mixed types workflows and blocks, we should put them into their own folders

https://github.ibm.com/ai-foundation/run-anywhere-tracker/issues/129