### PR TITLE
:bug: overwrite models on unpack

### DIFF
--- a/watson_embed_model_packager/resources/unpack_model.sh
+++ b/watson_embed_model_packager/resources/unpack_model.sh
@@ -57,7 +57,7 @@ mkdir -p "$model_dir"
 cd $model_dir
 
 # Unzip the target file
-unzip $input_path
+unzip -o $input_path
 
 # Update the input path to trigger the upload
 cd ..


### PR DESCRIPTION
This PR updates the unpack_model.sh script to overwrite the target directory when unzipping a model.

This fixes a problem where an initContainer crashes while unpacking a model, leaving a fully or partially unzipped model in the volume. Subsequent runs of the initContainer fail because they prompt to overwrite the existing files.

From `unzip --help`
```
-o  overwrite files WITHOUT prompting
```