### PR TITLE
Update dependency pyYAML >=6.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 alchemy-logging>=1.1.0,<2.0
 semver>=2.13.0,<3.0
 httpx>=0.23.0,<1.0
-PyYAML>=5.4.1,<6.0
+PyYAML>=6.0.0,<7.0


### PR DESCRIPTION
Issue with Cython_sources when installing pyYAML, see this build for failure https://github.com/IBM/ibm-watson-embed-model-builder/actions/runs/6114386965/job/16595842957#step:4:120