### PR TITLE
Allow for module_id and another id field, but they have to match

### DIFF
--- a/tests/test_setup_build_config.py
+++ b/tests/test_setup_build_config.py
@@ -990,6 +990,48 @@ def test_missing_module_class_in_config():
         assert len(model_entries) == 0
 
 
+def test_model_with_module_id_and_block_id_in_config_that_match():
+    """Make sure that model has module_id and block_id that match gets counted"""
+    with cli_test_harness(
+        {
+            f"/blocks/sample/{MODEL_NAME}": make_model_content(
+                {
+                    "block_class": "watson_nlp.blocks.sample.testing.Tester",
+                    "block_id": MODULE_GUID,
+                    "module_id": MODULE_GUID,
+                    "watson_nlp_version": "1.2.3",
+                }
+            )
+        },
+        "-m",
+        MODULE_GUID,
+    ) as output_csv:
+        command.main()
+        model_entries = parse_csv_file(output_csv)
+        assert len(model_entries) == 1
+
+
+def test_model_with_module_id_and_block_id_in_config_that_dont_match():
+    """Make sure that a model has module_id and block_id that don't match doesn't count"""
+    with cli_test_harness(
+        {
+            f"/blocks/sample/{MODEL_NAME}": make_model_content(
+                {
+                    "block_class": "watson_nlp.blocks.sample.testing.Tester",
+                    "block_id": MODULE_GUID,
+                    "module_id": "some other id",
+                    "watson_nlp_version": "1.2.3",
+                }
+            )
+        },
+        "-m",
+        MODULE_GUID,
+    ) as output_csv:
+        command.main()
+        model_entries = parse_csv_file(output_csv)
+        assert len(model_entries) == 0
+
+
 def test_version_not_a_semver():
     """Make sure that a bad version causes a model to be discarded"""
     with cli_test_harness(

--- a/watson_embed_model_packager/setup_build_config.py
+++ b/watson_embed_model_packager/setup_build_config.py
@@ -391,8 +391,21 @@ def update_model_info_from_config(
         key for key in config.keys() if key.endswith("_id") and key != "tracking_id"
     ]
     if len(id_fields) != 1:
-        log.warning("No single module guid found for model with config [%s]", config)
-        return None
+        # if one of them is module_id, make sure it matches the other _id field
+        if len(id_fields) == 2 and "module_id" in id_fields:
+            if config[id_fields[0]] != config[id_fields[1]]:
+                log.warning(
+                    "Found multiple id fields with different values: [%s] and [%s]",
+                    config[id_fields[0]],
+                    config[id_fields[1]],
+                )
+                return None
+        else:
+            log.warning(
+                "Either no id or too many id fields found for model with config [%s]",
+                config,
+            )
+            return None
     id_field = id_fields[0]
     module_guid = config[id_field]
 


### PR DESCRIPTION
We should accommodate for 2 id fields (`module_id` and either `block_id`/`workflow_id`), but we also check that their values match