### PR TITLE
update datetime parsing 

### DIFF
--- a/watson_embed_model_packager/setup_build_config.py
+++ b/watson_embed_model_packager/setup_build_config.py
@@ -464,7 +464,7 @@ def update_model_info_from_config(
         else:  # using artifactory model, so parse the date from model name
             # Need to look in the model name
             created_datetime = datetime.strptime(
-                model_path.split(".")[0].rpartition("_")[-1],
+                model_path.split(".")[-2].rpartition("_")[-1],
                 TIME_PARSE_FORMAT,
             )
             created = created_datetime.isoformat().replace("T", " ")


### PR DESCRIPTION
The field created_datetime is currently parsed from the 0th index after splitting model names by '.' .  Some new model names include '.' in places other than before the file extension.  For this reason, we need to update the parsing to take date from the penultimate ('-2') index, where datetime created will be reliably found due to naming conventions.