### PR TITLE
build: reduce amount of docker output while building

### DIFF
--- a/watson_embed_model_packager/build_model_images.py
+++ b/watson_embed_model_packager/build_model_images.py
@@ -112,7 +112,9 @@ def do_docker_build(
             log.info("Building without --platform")
             DOCKER_BUILD_COMMAND = "docker build"
 
-    build_cmd = f"{DOCKER_BUILD_COMMAND} . -f {dockerfile} -t {image_tag}"
+    build_cmd = (
+        f"{DOCKER_BUILD_COMMAND} . -f {dockerfile} -t {image_tag} --progress plain"
+    )
     for arg_name, arg_val in build_args.items():
         build_cmd += f" --build-arg {arg_name}={arg_val}"
     for label_name, label_val in build_labels.items():


### PR DESCRIPTION
This PR controls the verbosity of docker build. Using this [doc](https://docs.docker.com/reference/cli/docker/buildx/build/#progress)

I noticed we had very frequent logs in output, every 0.1s, that made Travis max out its maximum log length. Example [failed run ](https://v3.travis.ibm.com/github/ai-foundation/model-image-builder/jobs/28416100).

This PR hopefully reduces enough. Other alternative is using flag `--quiet` and mute all output altogether. 